### PR TITLE
fix: remove f" designation on string without placeholders

### DIFF
--- a/src/autora/workflow/base.py
+++ b/src/autora/workflow/base.py
@@ -72,7 +72,7 @@ class BaseController(Generic[State]):
         _logger.debug(f"{result=}")
 
         # Update
-        _logger.debug(f"updating state")
+        _logger.debug("updating state")
         self.state = result
 
         if self.monitor is not None:


### PR DESCRIPTION
remove f" designation on string without placeholders