### PR TITLE
chore: specify autora-core versions < 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "docs/index.md"
 license = {file = "LICENSE"}
 
 dependencies = [
-    "autora-core>=3.3.0",
+    "autora-core >= 3.3.0, <4",
     "scikit-learn",
     "matplotlib",
     "pandas",


### PR DESCRIPTION
... because only version 3 includes the state objects we use here. A new update will be needed for core version 4.